### PR TITLE
Fix comment display in takeaway tickets

### DIFF
--- a/pages/Takeaway.tsx
+++ b/pages/Takeaway.tsx
@@ -89,7 +89,7 @@ const TakeawayTicket: React.FC<{ commande: Commande, onFinalize: (id: string) =>
                             )}
                             {item.commentaire && (
                                 <div className="pl-6 text-sm text-yellow-800 italic">
-                                   "{item.commentaire}"
+                                    {item.commentaire}
                                 </div>
                             )}
                         </div>
@@ -160,7 +160,7 @@ const PendingTicket: React.FC<{ commande: Commande, onValidate: (id: string) => 
                         )}
                         {item.commentaire && (
                             <div className="pl-5 text-xs text-yellow-800 italic">
-                               "{item.commentaire}"
+                                {item.commentaire}
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
## Summary
- render takeaway item comments using the actual `item.commentaire` value
- ensure both ready and pending takeaway ticket views display customer notes correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d19c7b7ddc832aa3c8282c8a95595a