### PR TITLE
Ensure recettes persist produit identifiers

### DIFF
--- a/pages/CustomerOrder.tsx
+++ b/pages/CustomerOrder.tsx
@@ -375,7 +375,7 @@ const CustomerOrder: React.FC = () => {
                         {filteredProduits.map(produit => {
                              const quantity = totalQuantityPerProduct.get(produit.id) || 0;
                              const isAgotado = produit.estado !== 'disponible';
-                             const lowStockInfo = productLowStockInfo.get(produit.id);
+                            const lowStockInfo = productLowStockInfo.get(String(produit.id));
                              
                              return (
                                 <button

--- a/pages/Order.tsx
+++ b/pages/Order.tsx
@@ -312,7 +312,7 @@ const Order: React.FC = () => {
                                     {categoryProduits.map(produit => {
                                         const quantity = quantityInOrder.get(produit.id) || 0;
                                         const isAgotado = produit.estado !== 'disponible';
-                                        const lowStockInfo = productLowStockInfo.get(produit.id);
+                                        const lowStockInfo = productLowStockInfo.get(String(produit.id));
                                         
                                         return (
                                             <button

--- a/pages/Products.tsx
+++ b/pages/Products.tsx
@@ -454,7 +454,7 @@ const Products: React.FC = () => {
             
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                 {productsWithCost.map((p) => {
-                    const lowStockInfo = productLowStockInfo.get(p.id);
+                    const lowStockInfo = productLowStockInfo.get(String(p.id));
                     const statusInfo = getStatusInfo(p.estado);
                     const category = getCategoriaById(p.categoria_id);
                     return (

--- a/types.ts
+++ b/types.ts
@@ -47,7 +47,7 @@ export interface RecetteItem {
 }
 
 export interface Recette {
-    produit_id: number;
+    produit_id: number | string;
     items: RecetteItem[];
 }
 


### PR DESCRIPTION
## Summary
- persist the `produit_id` alongside recette items and backfill existing nodes while normalizing retrieved data
- allow recettes to use string identifiers and update restaurant data helpers to compare IDs using string keys
- align low stock lookups in ordering and product screens with the new string keyed map

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1a2167574832aa9d57ecf575bf737