### PR TITLE
feat: initialize new ingredient records with defaults

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -23,7 +23,9 @@ export interface Ingredient {
     last_known_price?: number;
 }
 
-export type IngredientPayload = Pick<Ingredient, 'nom' | 'unite' | 'stock_minimum'>;
+export type IngredientPayload =
+    Pick<Ingredient, 'nom' | 'unite' | 'stock_minimum'> &
+    Partial<Pick<Ingredient, 'stock_actuel' | 'prix_unitaire' | 'lots' | 'date_below_minimum' | 'last_known_price'>>;
 
 export interface Categoria {
     id: number;


### PR DESCRIPTION
## Summary
- extend the ingredient creation endpoint to persist default inventory fields and return them immediately
- allow ingredient payloads to include optional stock and metadata values so defaults can be overridden when provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1b21844a4832aae91931dfc7292ce