### PR TITLE
feat: secure firebase access with authenticated sessions

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -67,8 +67,9 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, closeSidebar }) => {
     
     const handleLogout = () => {
         closeSidebar();
-        logout();
-        navigate('/login');
+        void logout()
+            .catch(error => console.error('Erreur lors de la déconnexion', error))
+            .finally(() => navigate('/login'));
     };
 
     const NavItem: React.FC<NavItemProps> = ({ to, icon: Icon, label, notifications = [] }) => {

--- a/firebase_rules.json
+++ b/firebase_rules.json
@@ -1,57 +1,54 @@
-
 {
   "rules": {
+    ".read": false,
+    ".write": false,
     "users": {
-      ".read": "auth != null",
-      ".write": "auth != null", // Allows users to sign up
-      "$uid": {
-        ".read": "$uid === auth.uid",
-        ".write": "$uid === auth.uid || root.child('users').child(auth.uid).child('role').val() === 'admin'" // Users can edit their own data, or an admin can
-      }
+      ".read": "auth != null && ($uid === auth.uid || auth.token.roleId === 'admin')",
+      ".write": "auth != null && ($uid === auth.uid || auth.token.roleId === 'admin')"
     },
     "roles": {
-      // Only admins can read or write roles
-      ".read": "root.child('users').child(auth.uid).child('role').val() === 'admin'",
-      ".write": "root.child('users').child(auth.uid).child('role').val() === 'admin'"
+      ".read": "auth != null && auth.token.roleId === 'admin'",
+      ".write": "auth != null && auth.token.roleId === 'admin'"
     },
     "tables": {
       ".read": "auth != null",
-      ".write": "auth != null" // Any authenticated user (e.g. waiter) can manage tables
+      ".write": "auth != null"
     },
     "products": {
-      ".read": "auth != null",
-      ".write": "root.child('roles').child(root.child('users').child(auth.uid).child('role').val()).child('permissions').child('products').val() === 'editor'"
+      ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.products == 'editor' || auth.token.permissions.products == 'readonly')",
+      ".write": "auth != null && auth.token.permissions != null && auth.token.permissions.products == 'editor'"
     },
     "categories": {
-      ".read": "auth != null",
-       // Tied to product permissions
-      ".write": "root.child('roles').child(root.child('users').child(auth.uid).child('role').val()).child('permissions').child('products').val() === 'editor'"
+      ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.products == 'editor' || auth.token.permissions.products == 'readonly')",
+      ".write": "auth != null && auth.token.permissions != null && auth.token.permissions.products == 'editor'"
     },
     "ingredients": {
-      ".read": "auth != null",
-      ".write": "root.child('roles').child(root.child('users').child(auth.uid).child('role').val()).child('permissions').child('ingredients').val() === 'editor'"
+      ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.ingredients == 'editor' || auth.token.permissions.ingredients == 'readonly')",
+      ".write": "auth != null && auth.token.permissions != null && auth.token.permissions.ingredients == 'editor'"
     },
     "commands": {
       ".read": "auth != null",
-      ".write": "auth != null" // Any authenticated user (e.g. waiter) can manage commands
+      ".write": "auth != null"
     },
     "sales": {
-      ".read": "auth != null",
-       // Tied to reports permissions
-      ".write": "root.child('roles').child(root.child('users').child(auth.uid).child('role').val()).child('permissions').child('reports').val() === 'editor'"
+      ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.reports == 'editor' || auth.token.permissions.reports == 'readonly')",
+      ".write": "auth != null && auth.token.permissions != null && auth.token.permissions.reports == 'editor'"
     },
     "purchases": {
-      ".read": "auth != null",
-      // Tied to ingredients permissions
-      ".write": "root.child('roles').child(root.child('users').child(auth.uid).child('role').val()).child('permissions').child('ingredients').val() === 'editor'"
+      ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.ingredients == 'editor' || auth.token.permissions.ingredients == 'readonly')",
+      ".write": "auth != null && auth.token.permissions != null && auth.token.permissions.ingredients == 'editor'"
     },
     "site_configuration": {
       ".read": true,
-      ".write": "root.child('users').child(auth.uid).child('role').val() === 'admin'" // Only admins can change site config
+      ".write": "auth != null && auth.token.roleId === 'admin'"
     },
     "daily_reports": {
-      ".read": "auth != null",
-      ".write": "root.child('roles').child(root.child('users').child(auth.uid).child('role').val()).child('permissions').child('reports').val() === 'editor'"
+      ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.reports == 'editor' || auth.token.permissions.reports == 'readonly')",
+      ".write": "auth != null && auth.token.permissions != null && auth.token.permissions.reports == 'editor'"
+    },
+    "time_entries": {
+      ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.reports == 'editor' || auth.token.permissions.reports == 'readonly')",
+      ".write": false
     }
   }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,65 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+admin.initializeApp();
+
+const ALLOWED_ORIGINS = ['*'];
+
+exports.verifyPinAndIssueToken = functions.region('us-central1').https.onRequest(async (req, res) => {
+  if (req.method === 'OPTIONS') {
+    res.set('Access-Control-Allow-Origin', ALLOWED_ORIGINS[0]);
+    res.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.set('Access-Control-Allow-Headers', 'Content-Type');
+    res.status(204).send('');
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.set('Allow', 'POST, OPTIONS');
+    res.status(405).json({ error: 'method-not-allowed' });
+    return;
+  }
+
+  res.set('Access-Control-Allow-Origin', ALLOWED_ORIGINS[0]);
+
+  const pin = req.body && typeof req.body.pin === 'string' ? req.body.pin.trim() : '';
+  if (!pin) {
+    res.status(400).json({ error: 'invalid-pin' });
+    return;
+  }
+
+  try {
+    const rolesSnapshot = await admin.database().ref('roles').once('value');
+    const roles = rolesSnapshot.val() || {};
+
+    let matchedRoleId = null;
+    let matchedRoleData = null;
+    for (const [roleId, roleData] of Object.entries(roles)) {
+      if (roleData && typeof roleData === 'object' && roleData.pin === pin) {
+        matchedRoleId = roleId;
+        matchedRoleData = roleData;
+        break;
+      }
+    }
+
+    if (!matchedRoleId || !matchedRoleData) {
+      res.status(403).json({ error: 'invalid-pin' });
+      return;
+    }
+
+    const customClaims = {
+      roleId: matchedRoleId,
+      permissions: matchedRoleData.permissions || {},
+    };
+
+    const token = await admin.auth().createCustomToken(`role_${matchedRoleId}`, customClaims);
+
+    res.json({
+      token,
+      role: { id: matchedRoleId, ...matchedRoleData },
+    });
+  } catch (error) {
+    console.error('verifyPinAndIssueToken failure', error);
+    res.status(500).json({ error: 'internal-error' });
+  }
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ouioui-pin-auth-functions",
+  "description": "Cloud Functions pour l'authentification par PIN",
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^4.4.1"
+  }
+}

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -1,0 +1,69 @@
+import { signInWithCustomToken, signOut } from "firebase/auth";
+import type { Role } from "../types";
+import { auth, ensureFirebaseUser } from "./firebaseConfig";
+
+interface PinAuthResponse {
+  token: string;
+  role: Role;
+}
+
+const resolvePinAuthEndpoint = (): string => {
+  const explicitEndpoint = import.meta.env.VITE_PIN_AUTH_ENDPOINT as string | undefined;
+  if (explicitEndpoint && explicitEndpoint.trim() !== "") {
+    return explicitEndpoint;
+  }
+
+  const projectId = import.meta.env.VITE_PROJECT_ID as string | undefined;
+  const region = (import.meta.env.VITE_FUNCTIONS_REGION as string | undefined) || "us-central1";
+
+  if (import.meta.env.DEV) {
+    const emulatorPort = import.meta.env.VITE_FUNCTIONS_EMULATOR_PORT as string | undefined;
+    if (emulatorPort && projectId) {
+      return `http://localhost:${emulatorPort}/${projectId}/${region}/verifyPinAndIssueToken`;
+    }
+  }
+
+  if (projectId) {
+    return `https://${region}-${projectId}.cloudfunctions.net/verifyPinAndIssueToken`;
+  }
+
+  throw new Error("Aucun endpoint pour l'échange du PIN n'est configuré");
+};
+
+export const exchangePinForFirebaseToken = async (pin: string): Promise<PinAuthResponse> => {
+  const endpoint = resolvePinAuthEndpoint();
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ pin }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new Error(errorText || "Impossible de valider le PIN fourni");
+  }
+
+  const payload = await response.json() as Partial<PinAuthResponse>;
+  if (!payload?.token || !payload?.role) {
+    throw new Error("Réponse invalide du service d'authentification");
+  }
+
+  return payload as PinAuthResponse;
+};
+
+export const loginWithPin = async (pin: string): Promise<Role | null> => {
+  if (!pin) {
+    return null;
+  }
+
+  const { token, role } = await exchangePinForFirebaseToken(pin);
+  await signInWithCustomToken(auth, token);
+  return role;
+};
+
+export const logoutFromFirebase = async (): Promise<void> => {
+  await signOut(auth);
+  await ensureFirebaseUser();
+};

--- a/services/firebaseConfig.ts
+++ b/services/firebaseConfig.ts
@@ -1,6 +1,7 @@
 
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
+import { getAuth, onAuthStateChanged, signInAnonymously } from "firebase/auth";
 import { getDatabase, connectDatabaseEmulator } from "firebase/database";
 import { getStorage, connectStorageEmulator } from "firebase/storage";
 
@@ -19,9 +20,91 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 
-// Get a reference to the database service and storage service
+// Get references to Firebase services
+export const auth = getAuth(app);
 export const database = getDatabase(app);
 export const storage = getStorage(app);
+
+let resolveAuthReady: (() => void) | null = null;
+let authReadyPromise: Promise<void> | null = null;
+let anonymousSignInPromise: Promise<void> | null = null;
+
+const createAuthReadyPromise = () => {
+  authReadyPromise = new Promise<void>((resolve) => {
+    resolveAuthReady = resolve;
+  });
+};
+
+const ensureAuthReadyPromise = () => {
+  if (!authReadyPromise) {
+    createAuthReadyPromise();
+  }
+  return authReadyPromise!;
+};
+
+const resolveAuthPromise = () => {
+  if (resolveAuthReady) {
+    resolveAuthReady();
+    resolveAuthReady = null;
+  }
+};
+
+const startAnonymousSignIn = async (): Promise<void> => {
+  if (!anonymousSignInPromise) {
+    anonymousSignInPromise = signInAnonymously(auth)
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error("Erreur lors de la connexion anonyme à Firebase", error);
+        throw error;
+      })
+      .finally(() => {
+        anonymousSignInPromise = null;
+      });
+  }
+
+  try {
+    await anonymousSignInPromise;
+  } catch (error) {
+    // Propager l'erreur pour que les appels puissent la gérer.
+    throw error;
+  }
+};
+
+onAuthStateChanged(auth, (user) => {
+  if (user) {
+    resolveAuthPromise();
+  } else {
+    createAuthReadyPromise();
+  }
+});
+
+createAuthReadyPromise();
+
+export const ensureFirebaseUser = async (): Promise<void> => {
+  if (auth.currentUser) {
+    resolveAuthPromise();
+    return;
+  }
+
+  try {
+    await startAnonymousSignIn();
+  } catch (error) {
+    // Si la connexion anonyme échoue, attendre tout de même un utilisateur
+    // valide (par exemple un jeton personnalisé).
+    await ensureAuthReadyPromise();
+    throw error;
+  }
+
+  if (!auth.currentUser) {
+    await ensureAuthReadyPromise();
+  }
+};
+
+// Déclenche un premier cycle d'authentification pour éviter les conditions de course
+ensureFirebaseUser().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error("Impossible d'initialiser l'authentification Firebase", error);
+});
 
 /*
 // Connect to emulators in development - DISABLED BY USER REQUEST


### PR DESCRIPTION
## Summary
- initialize Firebase Auth alongside the database/storage clients and ensure an authenticated user (anonymous or custom token) before every Realtime Database or Storage call
- add a front-end auth service that exchanges verified PINs for Firebase custom tokens and wire login/logout in the restaurant data provider to manage Firebase sessions
- add a sample Cloud Function to mint custom tokens from PINs, tighten Realtime Database rules around custom claims, and make auxiliary updates (async logout handler)

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1be60430c832a8ecc9da5d2983e69