### PR TITLE
Align entity identifiers with EntityId

### DIFF
--- a/components/TableModal.tsx
+++ b/components/TableModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Card from './ui/Card';
 import { Loader2 } from 'lucide-react';
-import type { Table, TablePayload } from '../types';
+import type { EntityId, Table, TablePayload } from '../types';
 
 interface TableModalProps {
     isOpen: boolean;
@@ -28,7 +28,7 @@ const TableModal: React.FC<TableModalProps> = ({ isOpen, onClose, onSave, existi
                 setCapacite(String(existingTable.capacite));
             } else {
                 const numericIds = allTables
-                    .map(t => Number(t.id))
+                    .map(table => Number.parseInt(String(table.id), 10))
                     .filter(n => Number.isFinite(n) && n < 90);
                 const nextId = numericIds.length > 0 ? Math.max(...numericIds) + 1 : 1;
                 setId(String(nextId));
@@ -42,14 +42,15 @@ const TableModal: React.FC<TableModalProps> = ({ isOpen, onClose, onSave, existi
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         setError('');
-        const numId = Number(id);
+        const sanitizedId: EntityId = id.trim();
+        const numId = Number.parseInt(sanitizedId, 10);
         const numCapacite = parseInt(capacite, 10);
 
         if (!Number.isFinite(numId) || numId <= 0 || numId >= 90) {
             setError("El número de mesa debe ser un número positivo menor que 90.");
             return;
         }
-        if (isNew && allTables.some(t => String(t.id) === id)) {
+        if (isNew && allTables.some(t => String(t.id) === sanitizedId)) {
             setError("Este número de mesa ya existe.");
             return;
         }
@@ -64,7 +65,7 @@ const TableModal: React.FC<TableModalProps> = ({ isOpen, onClose, onSave, existi
 
         setIsSaving(true);
         try {
-            await onSave({ id: id, nom: nom.trim(), capacite: numCapacite }, isNew);
+            await onSave({ id: sanitizedId, nom: nom.trim(), capacite: numCapacite }, isNew);
             onClose();
         } catch (err: any) {
             setError(err.message || "Error al guardar la mesa.");

--- a/pages/History.tsx
+++ b/pages/History.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { useRestaurantData } from '../hooks/useRestaurantData';
 import Card from '../components/ui/Card';
-import type { Vente } from '../types';
+import type { EntityId, Produit, Vente } from '../types';
 import { Eye, X } from 'lucide-react';
 
 const formatCOP = (value: number) => new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(Math.round(value));
@@ -16,10 +16,10 @@ interface CommandeHistorique {
   items: Vente[];
 }
 
-const DetailsModal: React.FC<{ 
-    commande: CommandeHistorique, 
+const DetailsModal: React.FC<{
+    commande: CommandeHistorique,
     onClose: () => void,
-    getProduitById: (id: number) => any
+    getProduitById: (id: EntityId) => Produit | undefined
 }> = ({ commande, onClose, getProduitById }) => {
     return (
         <div className="fixed inset-0 bg-black bg-opacity-60 flex justify-center items-center z-50 p-4">

--- a/pages/Ingredients.tsx
+++ b/pages/Ingredients.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { useRestaurantData } from '../hooks/useRestaurantData';
 import Card from '../components/ui/Card';
 import { PackagePlus, Loader2, List, PlusCircle, Trash2, Edit } from 'lucide-react';
-import type { Ingredient, IngredientPayload, Unite } from '../types';
+import type { EntityId, Ingredient, IngredientPayload, Unite } from '../types';
 import { Unite as UniteEnum } from '../types';
 
 const formatCOP = (value: number) => new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(Math.round(value));
@@ -10,7 +10,7 @@ const formatCOP = (value: number) => new Intl.NumberFormat('es-CO', { style: 'cu
 const ReapprovisionnementModal: React.FC<{
     ingredient: Ingredient,
     onClose: () => void,
-    onAchat: (ingredientId: number, quantite: number, prix: number) => Promise<void>
+    onAchat: (ingredientId: EntityId, quantite: number, prix: number) => Promise<void>
 }> = ({ ingredient, onClose, onAchat }) => {
     const [quantite, setQuantite] = useState(0);
     const [prix, setPrix] = useState(0);
@@ -102,7 +102,7 @@ const IngredientDetailsModal: React.FC<{
 const IngredientModal: React.FC<{
     ingredient: Ingredient | null;
     onClose: () => void;
-    onSave: (payload: IngredientPayload, id?: number) => Promise<void>;
+    onSave: (payload: IngredientPayload, id?: EntityId) => Promise<void>;
 }> = ({ ingredient, onClose, onSave }) => {
     const [nom, setNom] = useState('');
     const [unite, setUnite] = useState<Unite>(UniteEnum.KG);
@@ -190,15 +190,15 @@ const Ingredients: React.FC = () => {
         setIsEditModalOpen(true);
     };
 
-    const handleSaveIngredient = async (payload: IngredientPayload, id?: number) => {
-        if (id) {
+    const handleSaveIngredient = async (payload: IngredientPayload, id?: EntityId) => {
+        if (id !== undefined) {
             await updateIngredient(id, payload);
         } else {
             await addIngredient(payload);
         }
     };
 
-    const handleDeleteIngredient = async (id: number, name: string) => {
+    const handleDeleteIngredient = async (id: EntityId, name: string) => {
         if (window.confirm(`¿Está seguro de que desea eliminar el ingrediente "${name}"?`)) {
             try {
                 await deleteIngredient(id);


### PR DESCRIPTION
## Summary
- ensure ingredient modals and delete handlers consistently use the EntityId alias
- tighten history modal product lookup types to work with EntityId-based identifiers
- sanitize table modal identifiers while keeping numeric calculations for automatic numbering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d19eed54d0832abbafa2c028aaa95f