### PR TITLE
Secure tables and commands access with new claims

### DIFF
--- a/firebase_rules.json
+++ b/firebase_rules.json
@@ -11,8 +11,8 @@
       ".write": "auth != null && auth.token.roleId === 'admin'"
     },
     "tables": {
-      ".read": "auth != null",
-      ".write": "auth != null"
+      ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.orders == 'editor' || auth.token.permissions.orders == 'readonly')",
+      ".write": "auth != null && auth.token.permissions != null && auth.token.permissions.orders == 'editor'"
     },
     "products": {
       ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.products == 'editor' || auth.token.permissions.products == 'readonly')",
@@ -27,8 +27,8 @@
       ".write": "auth != null && auth.token.permissions != null && auth.token.permissions.ingredients == 'editor'"
     },
     "commands": {
-      ".read": "auth != null",
-      ".write": "auth != null"
+      ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.orders == 'editor' || auth.token.permissions.orders == 'readonly')",
+      ".write": "auth != null && auth.token.permissions != null && auth.token.permissions.orders == 'editor'"
     },
     "sales": {
       ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.reports == 'editor' || auth.token.permissions.reports == 'readonly')",


### PR DESCRIPTION
## Summary
- enforce `permissions.orders` for tables and commands rules in Realtime Database
- derive and attach the new `permissions.orders` claim when issuing custom tokens, documenting eligible roles
- harden api service auth wrapper to surface access-denied errors, redirect to the login page, and only ensure Firebase auth when a role is expected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1d08ec350832ab45c2c8e92b9fdfd