### PR TITLE
Expose public menu snapshot and sync triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,44 @@ View your app in AI Studio: https://ai.studio/apps/drive/1iJ5atJAu7tHsxLPqDE6UpJ
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Public data surface
+
+The Firebase Realtime Database now exposes a dedicated `public_menu` node that mirrors a
+sanitised subset of the restaurant data. The Cloud Functions copy only the fields required by
+anonymous users:
+
+- **Products** – name, category, availability state, price and public image URL.
+- **Categories** – name only, filtered to those used by the public catalogue.
+- **Recipes** – ingredient references without cost or quantity information (quantities are
+  zeroed so preparation ratios stay private).
+- **Ingredients** – display name and unit so customers can request exclusions while stock and
+  pricing stay internal.
+- **Site assets** – marketing assets already intended for public rendering.
+
+Because the `public_menu` node is world-readable while the rest of the dataset remains locked
+down, the front-end can serve menu browsing and takeaway flows without an authenticated role.
+
+## Deployment workflow
+
+1. Deploy the updated security rules so the anonymous surface is read-only:
+   ```bash
+   firebase deploy --only database:rules
+   ```
+2. Deploy the new replication triggers (they run in `us-central1`):
+   ```bash
+   firebase deploy --only \
+     functions:publicMenuOnProductsWrite,\
+     functions:publicMenuOnCategoriesWrite,\
+     functions:publicMenuOnRecettesWrite,\
+     functions:publicMenuOnIngredientsWrite,\
+     functions:publicMenuOnSiteConfigWrite
+   ```
+3. After the first deployment, trigger an initial backfill (any write on the source nodes will
+   do). One option with the Firebase CLI is to reapply the existing site configuration:
+   ```bash
+   firebase database:get /site_configuration > /tmp/site_config.json
+   firebase database:update /site_configuration /tmp/site_config.json
+   ```
+   This causes the Cloud Function to recompute `public_menu`. Subsequent product/category/
+   recipe/ingredient/site configuration edits will keep the public node in sync automatically.

--- a/firebase_rules.json
+++ b/firebase_rules.json
@@ -49,6 +49,10 @@
     "time_entries": {
       ".read": "auth != null && auth.token.permissions != null && (auth.token.permissions.reports == 'editor' || auth.token.permissions.reports == 'readonly')",
       ".write": false
+    },
+    "public_menu": {
+      ".read": true,
+      ".write": false
     }
   }
 }

--- a/firebase_structure.json
+++ b/firebase_structure.json
@@ -97,5 +97,39 @@
       "totalSales": 1500,
       "customerCount": 50
     }
+  },
+  "public_menu": {
+    "categories": {
+      "category_id_1": {
+        "nom": "Pizzas"
+      }
+    },
+    "products": {
+      "product_id_1": {
+        "nom_produit": "Pizza Margherita",
+        "prix_vente": 12.5,
+        "categoria_id": "category_id_1",
+        "estado": "disponible"
+      }
+    },
+    "recettes": {
+      "product_id_1": {
+        "produit_id": "product_id_1",
+        "items": [
+          { "ingredient_id": "ingredient_id_1", "qte_utilisee": 0 }
+        ]
+      }
+    },
+    "ingredients": {
+      "ingredient_id_1": {
+        "nom": "Tomate",
+        "unite": "kg"
+      }
+    },
+    "site_assets": {
+      "restaurant_name": "My Restaurant",
+      "theme": "dark"
+    },
+    "updatedAt": 1715875200000
   }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -112,3 +112,224 @@ exports.verifyPinAndIssueToken = functions.region('us-central1').https.onRequest
     res.status(500).json({ error: 'internal-error' });
   }
 });
+
+// --- Public menu replication -------------------------------------------------
+
+const PUBLIC_MENU_PATH = 'public_menu';
+
+const toNumeric = (value, fallback = 0) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+};
+
+const toTrimmedString = (value) => {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return '';
+};
+
+const sanitizeCategoryRecord = (categoryId, rawCategory) => {
+  if (!rawCategory || typeof rawCategory !== 'object') {
+    return null;
+  }
+
+  const nom = toTrimmedString(rawCategory.nom);
+  if (!nom) {
+    return null;
+  }
+
+  return { nom };
+};
+
+const sanitizeProductRecord = (productId, rawProduct) => {
+  if (!rawProduct || typeof rawProduct !== 'object') {
+    return null;
+  }
+
+  const nom_produit = toTrimmedString(rawProduct.nom_produit);
+  if (!nom_produit) {
+    return null;
+  }
+
+  const categoria_id = toTrimmedString(rawProduct.categoria_id);
+  const estado = toTrimmedString(rawProduct.estado) || 'disponible';
+  const prix_vente = toNumeric(rawProduct.prix_vente);
+
+  const sanitizedProduct = {
+    nom_produit,
+    categoria_id,
+    estado,
+    prix_vente,
+  };
+
+  if (rawProduct.image_base64 && typeof rawProduct.image_base64 === 'string') {
+    sanitizedProduct.image_base64 = rawProduct.image_base64;
+  }
+
+  return sanitizedProduct;
+};
+
+const sanitizeRecetteRecord = (productId, rawRecette, usedIngredientIds) => {
+  const base = rawRecette && typeof rawRecette === 'object' ? rawRecette : {};
+  const itemsSource = Array.isArray(base.items)
+    ? base.items
+    : base.items && typeof base.items === 'object'
+      ? Object.values(base.items)
+      : Array.isArray(base)
+        ? base
+        : [];
+
+  const sanitizedItems = [];
+
+  for (const item of itemsSource) {
+    if (!item || typeof item !== 'object') {
+      continue;
+    }
+
+    const ingredientId = toTrimmedString(item.ingredient_id);
+    if (!ingredientId) {
+      continue;
+    }
+
+    usedIngredientIds.add(ingredientId);
+    sanitizedItems.push({ ingredient_id: ingredientId, qte_utilisee: 0 });
+  }
+
+  return {
+    produit_id: productId,
+    items: sanitizedItems,
+  };
+};
+
+const sanitizeIngredientRecord = (ingredientId, rawIngredient) => {
+  if (!rawIngredient || typeof rawIngredient !== 'object') {
+    return null;
+  }
+
+  const nom = toTrimmedString(rawIngredient.nom);
+  if (!nom) {
+    return null;
+  }
+
+  const unite = toTrimmedString(rawIngredient.unite) || 'unidad';
+
+  return {
+    nom,
+    unite,
+  };
+};
+
+const buildPublicMenuPayload = async () => {
+  const db = admin.database();
+  const [productsSnap, categoriesSnap, recettesSnap, ingredientsSnap, siteConfigSnap] = await Promise.all([
+    db.ref('products').once('value'),
+    db.ref('categories').once('value'),
+    db.ref('recettes').once('value'),
+    db.ref('ingredients').once('value'),
+    db.ref('site_configuration').once('value'),
+  ]);
+
+  const rawProducts = productsSnap.val() || {};
+  const rawCategories = categoriesSnap.val() || {};
+  const rawRecettes = recettesSnap.val() || {};
+  const rawIngredients = ingredientsSnap.val() || {};
+  const siteAssets = siteConfigSnap.val() || {};
+
+  const sanitizedProducts = {};
+  const usedCategoryIds = new Set();
+
+  for (const [productId, productValue] of Object.entries(rawProducts)) {
+    const sanitizedProduct = sanitizeProductRecord(productId, productValue);
+    if (!sanitizedProduct) {
+      continue;
+    }
+
+    sanitizedProducts[productId] = sanitizedProduct;
+    if (sanitizedProduct.categoria_id) {
+      usedCategoryIds.add(sanitizedProduct.categoria_id);
+    }
+  }
+
+  const sanitizedCategories = {};
+  for (const [categoryId, categoryValue] of Object.entries(rawCategories)) {
+    if (usedCategoryIds.size > 0 && !usedCategoryIds.has(categoryId)) {
+      continue;
+    }
+    const sanitizedCategory = sanitizeCategoryRecord(categoryId, categoryValue);
+    if (!sanitizedCategory) {
+      continue;
+    }
+    sanitizedCategories[categoryId] = sanitizedCategory;
+  }
+
+  const usedIngredientIds = new Set();
+  const sanitizedRecettes = {};
+  for (const [recetteKey, recetteValue] of Object.entries(rawRecettes)) {
+    if (!sanitizedProducts[recetteKey]) {
+      continue;
+    }
+    const sanitizedRecette = sanitizeRecetteRecord(recetteKey, recetteValue, usedIngredientIds);
+    sanitizedRecettes[recetteKey] = sanitizedRecette;
+  }
+
+  const sanitizedIngredients = {};
+  for (const ingredientId of usedIngredientIds) {
+    const rawIngredient = rawIngredients[ingredientId];
+    const sanitizedIngredient = sanitizeIngredientRecord(ingredientId, rawIngredient);
+    if (!sanitizedIngredient) {
+      continue;
+    }
+    sanitizedIngredients[ingredientId] = sanitizedIngredient;
+  }
+
+  return {
+    updatedAt: admin.database.ServerValue.TIMESTAMP,
+    categories: sanitizedCategories,
+    products: sanitizedProducts,
+    recettes: sanitizedRecettes,
+    ingredients: sanitizedIngredients,
+    site_assets: siteAssets,
+  };
+};
+
+const syncPublicMenuData = async () => {
+  const payload = await buildPublicMenuPayload();
+  await admin.database().ref(PUBLIC_MENU_PATH).set(payload);
+};
+
+const buildPublicMenuTrigger = (path) =>
+  functions
+    .region('us-central1')
+    .database.ref(path)
+    .onWrite(async () => {
+      try {
+        await syncPublicMenuData();
+      } catch (error) {
+        console.error(`public_menu sync failed after change in ${path}`, error);
+        throw error;
+      }
+    });
+
+const PUBLIC_MENU_TRIGGER_PATHS = [
+  { exportName: 'publicMenuOnProductsWrite', path: '/products/{productId}' },
+  { exportName: 'publicMenuOnCategoriesWrite', path: '/categories/{categoryId}' },
+  { exportName: 'publicMenuOnRecettesWrite', path: '/recettes/{recetteId}' },
+  { exportName: 'publicMenuOnIngredientsWrite', path: '/ingredients/{ingredientId}' },
+  { exportName: 'publicMenuOnSiteConfigWrite', path: '/site_configuration/{configKey}' },
+];
+
+for (const { exportName, path } of PUBLIC_MENU_TRIGGER_PATHS) {
+  exports[exportName] = buildPublicMenuTrigger(path);
+}

--- a/hooks/useRestaurantData.tsx
+++ b/hooks/useRestaurantData.tsx
@@ -110,20 +110,39 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const fetchMenuData = useCallback(async () => {
         setLoading(true);
         setError(null);
+        setVentes([]);
+        setAchats([]);
+        setTables([]);
+        setKitchenOrders([]);
+        setReadyTakeawayOrders([]);
+        setPendingTakeawayOrders([]);
+        setActiveCommandes([]);
+        setRoles([]);
+        setProductLowStockInfo(new Map<string, string[]>());
+        setIngredients([]);
+        setProduits([]);
+        setRecettes([]);
+        setCategorias([]);
+        setSiteAssets(defaultImageAssets);
+
         try {
-            const [ingData, prodData, recData, catData, assetsData] = await Promise.all([
-                api.getIngredients(),
-                api.getProduits(),
-                api.getRecettes(),
-                api.getCategories(),
-                api.getSiteAssets(),
-            ]);
+            const { produits: prodData, categorias: catData, recettes: recData, ingredients: ingData, siteAssets } = await api.getPublicMenuData();
+
             setIngredients(ingData);
             setProduits(prodData);
             setRecettes(recData);
             setCategorias(catData);
-            setSiteAssets(assetsData);
+
+            const mergedAssets: SiteAssets = siteAssets && Object.keys(siteAssets).length > 0
+                ? { ...defaultImageAssets, ...(siteAssets as Partial<SiteAssets>) }
+                : defaultImageAssets;
+            setSiteAssets(mergedAssets);
         } catch (err) {
+            setIngredients([]);
+            setProduits([]);
+            setRecettes([]);
+            setCategorias([]);
+            setSiteAssets(defaultImageAssets);
             setError(err as Error);
         } finally {
             setLoading(false);


### PR DESCRIPTION
## Summary
- add Realtime Database triggers that mirror sanitised menu data into a world-readable public_menu node
- expose a dedicated API helper and hook flow so anonymous users read from the public surface instead of privileged paths
- document the deployment steps, adjust database rules, and update the sample structure to reflect the new public node

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1d4112a40832ab39d7020523daef7