### PR TITLE
Restrict storage access by role claims and sanitize site assets

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -1,8 +1,43 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
+    function isAuthenticated() {
+      return request.auth != null &&
+        request.auth.token.roleId is string &&
+        request.auth.token.roleId != '';
+    }
+
+    function getPermission(path) {
+      return isAuthenticated() && request.auth.token.permissions is map
+        ? request.auth.token.permissions[path]
+        : null;
+    }
+
+    function hasReadAccess(path) {
+      return getPermission(path) == 'editor' || getPermission(path) == 'readonly';
+    }
+
+    function hasWriteAccess(path) {
+      return getPermission(path) == 'editor';
+    }
+
+    match /site_assets/{assetPath=**} {
+      allow read: if hasReadAccess('/site-editor');
+      allow write: if hasWriteAccess('/site-editor');
+    }
+
+    match /product_images/{imagePath=**} {
+      allow read: if hasReadAccess('/produits');
+      allow write: if hasWriteAccess('/produits');
+    }
+
+    match /takeaway_receipts/{receiptPath=**} {
+      allow read: if hasReadAccess('/para-llevar');
+      allow write: if hasWriteAccess('/para-llevar');
+    }
+
     match /{allPaths=**} {
-      allow read, write: if request.auth != null;
+      allow read, write: if false;
     }
   }
 }


### PR DESCRIPTION
## Summary
- tighten Firebase Storage rules to require role claims for site, product and takeaway asset paths
- improve access denied handling in the API service and surface a clearer message when a privileged role is required
- load site assets from the replicated public_menu payload (with fallback) so public renders rely on signed URLs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1d74edcb0832ab99c60c54bcea219