### PR TITLE
Restrict PIN auth CORS to admin origins

### DIFF
--- a/docs/pense-bete-netlify-firebase.md
+++ b/docs/pense-bete-netlify-firebase.md
@@ -1,0 +1,20 @@
+# Pense-bête Netlify / Firebase
+
+## API d'authentification PIN
+
+- La fonction Cloud `verifyPinAndIssueToken` n'accepte que les origines suivantes :
+  - https://admin.ouiouitacos.com
+  - https://ouiouitacos-admin.netlify.app
+  - https://main--ouiouitacos-admin.netlify.app
+- Toute requête (POST ou prévol `OPTIONS`) provenant d'une autre origine reçoit une réponse **403 origin-not-allowed**.
+- Mettre à jour la liste dans `functions/index.js` en cas d'ajout/suppression de domaines frontaux.
+
+## Déploiement Firebase
+
+Après modification de la fonction :
+
+```bash
+firebase deploy --only functions:verifyPinAndIssueToken
+```
+
+Penser à monitorer la console Firebase pour vérifier l'absence d'erreurs et tester l'authentification depuis l'interface Admin Netlify une fois le déploiement terminé.


### PR DESCRIPTION
## Summary
- lock the verifyPinAndIssueToken function to the approved Netlify/Admin origins and reject other origins with a 403
- document the allowed origin list and redeploy command in the Netlify/Firebase runbook

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1d9e9da68832aa1018088a8adedd5